### PR TITLE
Package script updates

### DIFF
--- a/dev/template-values-production.json
+++ b/dev/template-values-production.json
@@ -1,0 +1,28 @@
+{
+  "repository": {
+    "name": "sanity-minecraft-blog",
+    "owner": "sanity-io",
+    "private": false
+  },
+  "sanity": {
+    "dataset": "blog",
+    "projectId": "jmhf2rn8",
+    "projectTitle": "Minecraft blog (dev)"
+  },
+  "user": {
+    "profileImage": "https://static.wikia.nocookie.net/characters/images/b/b3/SteveMinecraft.png/revision/latest?cb=20160127082617",
+    "displayName": "Minecraft Steve",
+    "email": "not_a_real_person@fakesite.com"
+  },
+  "userInput": {},
+  "deployments": {
+    "studio": {
+      "url": "https://sanity-minecraft-blog-studio-rf4qpk9y.netlify.com/",
+      "providerName": "netlify",
+      "providerInfo": {
+        "buildHookId": "5cc04d5199df1802277a6e91",
+        "siteId": "58275684-e35f-46ee-9fda-a5151927cfb5        "
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,14 +3,13 @@
   "name": "sanity-template-minecraft-blog",
   "scripts": {
     "netlify:build-studio": "npm run build && cd build && npm install && npm run build-studio && cp studio/netlify.toml studio/dist",
-    "build": "sanity-template build",
+    "build": "sanity-template build --template-values dev/template-values-production.json",
     "copy-node-modules": "npm run copy-studio-node-modules && npm run copy-web-node-modules",
     "copy-studio-node-modules": "cp -R build/studio/node_modules template/studio/node_modules",
     "dev": "sanity-template watch --template-values dev/template-values-development.json",
     "lint-commit": "prettier-eslint \"{src/**/*,test/**/*,packages/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
     "lint-build": "npm run build && (cd build && npm install && npm run lint)",
     "setup": "npm run build && cd build && npm install && npm run build",
-    "test-studio": "cd build/studio && npm run dev",
     "prepare": "node -e \"if(require('fs').existsSync('.git')){process.exit(1)}\" || husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

Still hitting some friction on the Netlify deployment integration; seems that it _doesn't_ require `npm`; the error log cited in the previous PR appears to be a side effect of the actual issue.

Upon further review, I found that the issue is with the `postinstall` command, though I'm not sure what the issue is as it doesn't happen locally. This PR is more of an experimental change to see if the Netlify integration for the Sanity starter will work. If not, I'll start diving into their logs to see what happened.