### PR TITLE
Add pre push husky hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+([ -z \"$SKIP_HOOK\" ] && sanity-template lockfiles && git add '*package-lock.json*' && git diff --quiet && SKIP_HOOK=1 git commit -m 'chore: generate lockfiles') && echo 'Committed lockfiles' || echo ''

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dev": "sanity-template watch --template-values dev/template-values-development.json",
     "lint-commit": "prettier-eslint \"{src/**/*,test/**/*,packages/**/*}.{ts,tsx}\" --eslint-config-path=.eslintrc.yml --write",
     "lint-build": "npm run build && (cd build && npm install && npm run lint)",
-    "setup": "npm run build && cd build && npm install && npm run build",
-    "prepare": "node -e \"if(require('fs').existsSync('.git')){process.exit(1)}\" || husky install"
+    "prepare": "node -e \"if(require('fs').existsSync('.git')){process.exit(1)}\" || husky install",
+    "test": "npm run build && cd build && npm install && npm run build"
   },
   "devDependencies": {
     "@sanity/types": "^2.10.0",


### PR DESCRIPTION
# Description

There still seems to be an issue with the missing lock files. After reviewing the reference repo, I found there was an a Husky hook that seems responsible for copying the lock files. Going to give this a shot and will update this PR message, if this turns out to be the fix.